### PR TITLE
Support partial application on `func`

### DIFF
--- a/src/__tests__/container.test.ts
+++ b/src/__tests__/container.test.ts
@@ -65,6 +65,15 @@ describe('func', () => {
     expect(fn1()).toBe(5);
     expect(fn2()).toBe(6);
   });
+
+  test('supports partial application of 1 on function with 2 params', () => {
+    const add = (a: number, b: number) => a + b;
+    const container = createContainer()
+      .register('one', value(1))
+      .register('addOne', func(add, 'one'));
+
+    expect(container.resolve('addOne')(2)).toBe(3);
+  });
 });
 
 describe('value', () => {

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -41,7 +41,7 @@ export function singleton<TVal, TDependencies extends Record<string, unknown>>(
 export function func<
   TParams extends readonly unknown[],
   TReturn,
-  TDependencies extends MapTupleTo<TParams, string>
+  TDependencies extends readonly string[]
 >(
   fn: (...args: TParams) => TReturn,
   ...args: TDependencies
@@ -52,10 +52,11 @@ export function func<
   >
 > {
   return (container) => {
-    return () =>
+    return (...curriedArgs) =>
       fn(
         // @ts-expect-error
-        ...args.map((arg) => container.resolve(arg))
+        ...args.map((arg) => container.resolve(arg)),
+        ...curriedArgs
       );
   };
 }


### PR DESCRIPTION
Closes #1

WIP, need to figure out the types...

I have been using the `curry` example from the original variadic tuple types PR (https://github.com/microsoft/TypeScript/pull/39094) as inspiration but I can't see to encorporate it here.